### PR TITLE
#24-코드 최적화

### DIFF
--- a/src/main/java/com/bokyoung/preorderservice/controller/NewsFeedController.java
+++ b/src/main/java/com/bokyoung/preorderservice/controller/NewsFeedController.java
@@ -1,0 +1,30 @@
+package com.bokyoung.preorderservice.controller;
+
+import com.bokyoung.preorderservice.controller.response.NewsFeedResponse;
+import com.bokyoung.preorderservice.controller.response.Response;
+import com.bokyoung.preorderservice.exception.ErrorCode;
+import com.bokyoung.preorderservice.exception.PreOrderServiceException;
+import com.bokyoung.preorderservice.model.UserAccount;
+import com.bokyoung.preorderservice.service.NewsFeedService;
+import com.bokyoung.preorderservice.util.ClassUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/newsFeed")
+@RequiredArgsConstructor
+public class NewsFeedController {
+
+    private final NewsFeedService newsFeedService;
+
+    @GetMapping
+    public Response<Page<NewsFeedResponse>> newsFeed(Pageable pageable, Authentication authentication) {
+        UserAccount userAccount = ClassUtils.getSafeCastInstance(authentication.getPrincipal(), UserAccount.class);
+        return Response.success(newsFeedService.newsFeedsList(userAccount.getId(), pageable).map(NewsFeedResponse::fromNewsFeed));
+    }
+}

--- a/src/main/java/com/bokyoung/preorderservice/controller/UserController.java
+++ b/src/main/java/com/bokyoung/preorderservice/controller/UserController.java
@@ -1,14 +1,10 @@
 package com.bokyoung.preorderservice.controller;
 
 import com.bokyoung.preorderservice.controller.request.UserUpdateRequest;
-import com.bokyoung.preorderservice.controller.response.NewsFeedResponse;
 import com.bokyoung.preorderservice.controller.response.Response;
 import com.bokyoung.preorderservice.controller.response.UserUpdateResponse;
 import com.bokyoung.preorderservice.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -36,11 +32,6 @@ public class UserController {
     @GetMapping("/{id}")
     public Response<Void> getProfile() {
         return Response.success();
-    }
-
-    @GetMapping("/newsFeed")
-    public Response<Page<NewsFeedResponse>> newsFeed(Pageable pageable, Authentication authentication) {
-        return Response.success(userService.newsFeedsList(authentication.getName(), pageable).map(NewsFeedResponse::fromNewsFeed));
     }
 
 }

--- a/src/main/java/com/bokyoung/preorderservice/repository/NewsFeedRepository.java
+++ b/src/main/java/com/bokyoung/preorderservice/repository/NewsFeedRepository.java
@@ -10,5 +10,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface NewsFeedRepository extends JpaRepository<NewsFeedEntity, Long> {
 
-    Page<NewsFeedEntity> findAllByUserAccount(UserAccountEntity userAccount, Pageable pageable);
+    Page<NewsFeedEntity> findAllByUserAccountId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/bokyoung/preorderservice/service/NewsFeedService.java
+++ b/src/main/java/com/bokyoung/preorderservice/service/NewsFeedService.java
@@ -1,0 +1,19 @@
+package com.bokyoung.preorderservice.service;
+
+import com.bokyoung.preorderservice.model.NewsFeed;
+import com.bokyoung.preorderservice.repository.NewsFeedRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NewsFeedService {
+
+    private final NewsFeedRepository newsFeedRepository;
+
+    public Page<NewsFeed> newsFeedsList(Long userId, Pageable pageable) {
+        return newsFeedRepository.findAllByUserAccountId(userId, pageable).map(NewsFeed::fromEntity);
+    }
+}

--- a/src/main/java/com/bokyoung/preorderservice/service/UserService.java
+++ b/src/main/java/com/bokyoung/preorderservice/service/UserService.java
@@ -2,14 +2,11 @@ package com.bokyoung.preorderservice.service;
 
 import com.bokyoung.preorderservice.exception.ErrorCode;
 import com.bokyoung.preorderservice.exception.PreOrderServiceException;
-import com.bokyoung.preorderservice.model.NewsFeed;
 import com.bokyoung.preorderservice.model.UserAccount;
 import com.bokyoung.preorderservice.model.entity.UserAccountEntity;
 import com.bokyoung.preorderservice.repository.NewsFeedRepository;
 import com.bokyoung.preorderservice.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,12 +43,5 @@ public class UserService {
 
         userAccountEntity = userAccountRepository.save(UserAccountEntity.of(password, nickName, greeting, profile_image));
         return userAccountEntity.getId();
-    }
-
-    public Page<NewsFeed> newsFeedsList(String email, Pageable pageable) {
-        UserAccountEntity userAccount = userAccountRepository.findByEmail(email).orElseThrow(() ->
-                new PreOrderServiceException(ErrorCode.USER_NOT_FOUND, String.format("%s is not founded", email)));
-
-        return newsFeedRepository.findAllByUserAccount(userAccount, pageable).map(NewsFeed::fromEntity);
     }
 }

--- a/src/main/java/com/bokyoung/preorderservice/util/ClassUtils.java
+++ b/src/main/java/com/bokyoung/preorderservice/util/ClassUtils.java
@@ -1,0 +1,10 @@
+package com.bokyoung.preorderservice.util;
+
+import java.util.Optional;
+
+public class ClassUtils {
+
+    public static <T> T getSafeCastInstance(Object o, Class<T> clazz) {
+        return clazz != null && clazz.isInstance(o) ? clazz.cast(o) : null;
+    }
+}


### PR DESCRIPTION
- 뉴스피드 조회 시 회원을 중복 조회하는 로직 제거. Token 인증 시 user를 조회하고 이후 또 user를 조회하는 구조 (NewsFeed 관련 클래스, 클래스 casting을 안전하게 처리하기 위한 ClassUtils 생성 )
- 뉴스피드 조회 로직을 userService에서 newsFeedService로 기능에 따라 분리함 -불필요한 import 제거(UserController)